### PR TITLE
Rework sym_tensors and antisym_tensors assumptions on the container classes

### DIFF
--- a/adcgen/eri_orbenergy.py
+++ b/adcgen/eri_orbenergy.py
@@ -54,9 +54,9 @@ class EriOrbenergy:
         #       But if we keep it like it is, we should have a more clear
         #       definition of the prefactor (only the sign might be ambiguous
         #       +0.5 vs -0.5)
-        self._pref: Expr = min(  # type: ignore
+        self._pref: Expr = min(
             [t.prefactor for t in splitted["num"].terms],
-            key=abs  # type: ignore
+            key=abs
         )
 
         # only possiblity to extract 0 should be if the numerator is 0
@@ -332,9 +332,7 @@ class EriOrbenergy:
         num.expand()
         # this possibly introduced prefactors in the numerator again
         # -> extract the smallest prefactor and shift to self.pref
-        additional_pref = min(  # type: ignore
-            [t.prefactor for t in num.terms], key=abs  # type: ignore
-        )
+        additional_pref = min([t.prefactor for t in num.terms], key=abs)
         self._pref *= additional_pref
         if additional_pref is S.Zero:  # permuted num = 0
             if not num.inner.is_number:
@@ -472,7 +470,7 @@ class EriOrbenergy:
                 #    in the new numerator
                 # -> can only cancel each bracket at most 1 time
                 # -> no need to recurse just iterate through the list
-                min_pref = min(relevant_prefs, key=abs)  # type: ignore
+                min_pref = min(relevant_prefs, key=abs)
                 # the sign in the numerator has been fixed before entering this
                 # function -> dont change it!
                 if min_pref < 0:

--- a/adcgen/eri_orbenergy.py
+++ b/adcgen/eri_orbenergy.py
@@ -558,9 +558,8 @@ class EriOrbenergy:
             return self.denom
 
         symbolic_denom = ExprContainer(1, **self.denom.assumptions)
-        has_symbolic_denom = False
         for bracket in self.denom_brackets:
-            signs = {'-': set(), '+': set()}
+            signs = {"-": set(), "+": set()}
             for term in bracket.terms:
                 idx = term.idx
                 if len(idx) != 1:
@@ -570,28 +569,23 @@ class EriOrbenergy:
                                        f"Found: {term} in {bracket}.")
                 pref = term.prefactor
                 if pref is S.One:
-                    signs['+'].add(idx[0])
+                    signs["+"].add(idx[0])
                 elif pref is S.NegativeOne:
-                    signs['-'].add(idx[0])
+                    signs["-"].add(idx[0])
                 else:
                     raise RuntimeError(f"Found invalid prefactor {pref} in "
                                        f"denominator bracket {bracket}.")
-            if signs['+'] & signs['-']:
+            if signs["+"] & signs["-"]:
                 raise RuntimeError(f"Found index that is added and "
                                    f"subtracted in a denominator: {bracket}.")
-            has_symbolic_denom = True
             exponent = (
                     S.One if isinstance(bracket, ExprContainer)
                     else bracket.exponent
             )
             symbolic_denom *= Pow(SymmetricTensor(
-                tensor_names.sym_orb_denom, tuple(signs['+']),
-                tuple(signs['-']), -1
+                tensor_names.sym_orb_denom, tuple(signs["+"]),
+                tuple(signs["-"]), -1
             ), exponent)
-        if has_symbolic_denom:
-            symbolic_denom.antisym_tensors = (
-                symbolic_denom.antisym_tensors + (tensor_names.sym_orb_denom,)
-            )
         return symbolic_denom
 
 

--- a/adcgen/expression/container.py
+++ b/adcgen/expression/container.py
@@ -1,9 +1,10 @@
 from collections.abc import Iterable
 from typing import Any, TYPE_CHECKING
 
-from sympy import Expr, latex, sympify
+from sympy import Expr, latex, S, sympify
 
 from ..indices import Index, order_substitutions
+from ..sympy_objects import AntiSymmetricTensor
 
 # imports only required for type checking (avoid circular imports)
 if TYPE_CHECKING:
@@ -55,6 +56,28 @@ class Container:
     @property
     def inner(self) -> Expr:
         return self._inner
+
+    @property
+    def braket_sym_tensors(self) -> tuple[str, ...]:
+        """
+        Returns the names of all tensors with bra-ket-symmetry, i.e.,
+        all tensors with d^{pq}_{rs} = d^{rs}_{pq}.
+        """
+        return tuple(sorted(set(
+            tensor.name for tensor in self.inner.atoms(AntiSymmetricTensor)
+            if tensor.bra_ket_sym is S.One
+        )))
+
+    @property
+    def braket_antisym_tensors(self) -> tuple[str, ...]:
+        """
+        Returns the names of all tensors with bra-ket-antisymmetry, i.e.,
+        all tensors with d^{pq}_{rs} = -d^{rs}_{pq}.
+        """
+        return tuple(sorted(set(
+            tensor.name for tensor in self.inner.atoms(AntiSymmetricTensor)
+            if tensor.bra_ket_sym is S.NegativeOne
+        )))
 
     def permute(self, *perms: tuple[Index, Index]) -> "ExprContainer":
         """

--- a/adcgen/expression/container.py
+++ b/adcgen/expression/container.py
@@ -19,18 +19,6 @@ class Container:
     ----------
     inner: Expr | Container | Any
         The algebraic expression to wrap, e.g., a sympy.Add or sympy.Mul object
-    real : bool, optional
-        Whether the expression is represented in a real orbital basis.
-    sym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-symmetry, i.e.,
-        d^{pq}_{rs} = d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional symmetry if they are not aware
-        of it yet.
-    antisym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-antisymmetry, i.e.,
-        d^{pq}_{rs} = - d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional antisymmetry if they are not
-        aware of it yet.
     target_idx: Iterable[Index] | None, optional
         Target indices of the expression. By default the Einstein sum
         convention will be used to identify target and contracted indices,
@@ -38,9 +26,6 @@ class Container:
     """
 
     def __init__(self, inner: "Expr | Container | Any",
-                 real: bool = False,
-                 sym_tensors: Iterable[str] = tuple(),
-                 antisym_tensors: Iterable[str] = tuple(),
                  target_idx: Iterable[Index] | None = None) -> None:
         # possibly extract or import the expression to wrap
         if isinstance(inner, Container):
@@ -49,20 +34,7 @@ class Container:
             inner = sympify(inner)
             assert isinstance(inner, Expr)
         self._inner: Expr = inner
-        # set the assumptions
-        self._real: bool = real
-
-        if isinstance(sym_tensors, str):
-            sym_tensors = (sym_tensors,)
-        elif not isinstance(sym_tensors, tuple):
-            sym_tensors = tuple(sym_tensors)
-        self._sym_tensors: tuple[str, ...] = sym_tensors
-
-        if isinstance(antisym_tensors, str):
-            antisym_tensors = (antisym_tensors,)
-        elif not isinstance(antisym_tensors, tuple):
-            antisym_tensors = tuple(antisym_tensors)
-        self._antisym_tensors: tuple[str, ...] = antisym_tensors
+        # set the assumptions: the target indices
         if target_idx is not None and not isinstance(target_idx, tuple):
             target_idx = tuple(target_idx)
         self._target_idx: tuple[Index, ...] | None = target_idx
@@ -73,23 +45,8 @@ class Container:
     @property
     def assumptions(self) -> dict[str, Any]:
         return {
-            "real": self.real,
-            "sym_tensors": self.sym_tensors,
-            "antisym_tensors": self.antisym_tensors,
             "target_idx": self.provided_target_idx,
         }
-
-    @property
-    def real(self) -> bool:
-        return self._real
-
-    @property
-    def sym_tensors(self) -> tuple[str, ...]:
-        return self._sym_tensors
-
-    @property
-    def antisym_tensors(self) -> tuple[str, ...]:
-        return self._antisym_tensors
 
     @property
     def provided_target_idx(self) -> tuple[Index, ...] | None:

--- a/adcgen/expression/expr_container.py
+++ b/adcgen/expression/expr_container.py
@@ -429,9 +429,6 @@ class ExprContainer(Container):
                 raise TypeError("Assumptions need to be equal. Got: "
                                 f"{self.assumptions} and {other.assumptions}")
             other = other.inner
-        elif isinstance(other, Basic):
-            # Apply the assumptions to the sympy object
-            other = ExprContainer(other, **self.assumptions).inner
         res = self.inner + other
         assert isinstance(res, Expr)
         self._inner = res
@@ -443,9 +440,6 @@ class ExprContainer(Container):
                 raise TypeError("Assumptions need to be equal. Got: "
                                 f"{self.assumptions} and {other.assumptions}")
             other = other.inner
-        elif isinstance(other, Basic):
-            # Apply the assumptions to the sympy object
-            other = ExprContainer(other, **self.assumptions).inner
         res = self.inner - other
         assert isinstance(res, Expr)
         self._inner = res
@@ -457,9 +451,6 @@ class ExprContainer(Container):
                 raise TypeError("Assumptions need to be equal. Got: "
                                 f"{self.assumptions} and {other.assumptions}")
             other = other.inner
-        elif isinstance(other, Basic):
-            # Apply the assumptions to the sympy object
-            other = ExprContainer(other, **self.assumptions).inner
         res = self.inner * other
         assert isinstance(res, Expr)
         self._inner = res
@@ -471,8 +462,6 @@ class ExprContainer(Container):
                 raise TypeError("Assumptions need to be equal. Got: "
                                 f"{self.assumptions} and {other.assumptions}")
             other = other.inner
-        elif isinstance(other, Basic):
-            other = ExprContainer(other, **self.assumptions).inner
         res = self.inner / other
         assert isinstance(res, Expr)
         self._inner = res

--- a/adcgen/expression/expr_container.py
+++ b/adcgen/expression/expr_container.py
@@ -191,8 +191,15 @@ class ExprContainer(Container):
         braket_sym_tensors and braket_antisym_tensors to the tensor objects
         in the expression.
         """
+        if any(name in braket_sym_tensors for name in braket_antisym_tensors):
+            raise ValueError("Can not simultaneously add bra-ket-symmetry and "
+                             "-antisymmetry to a tensor: "
+                             f"sym_tensors {braket_sym_tensors}, "
+                             f"antisym_tensors {braket_antisym_tensors}.")
+
         if self.inner.is_number:  # nothing to do
             return self
+
         res = S.Zero
         for term in self.terms:
             res += term._apply_tensor_braket_sym(

--- a/adcgen/expression/expr_container.py
+++ b/adcgen/expression/expr_container.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Sequence
 from typing import Any
 
-from sympy import Add, Basic, Expr, Mul, Pow, S, Symbol, factor, nsimplify
+from sympy import Add, Basic, Expr, Mul, Pow, S, factor, nsimplify
 
 from ..indices import (
     Index, get_symbols, sort_idx_canonical,
@@ -22,6 +22,8 @@ class ExprContainer(Container):
         The algebraic expression to wrap, e.g., a sympy.Add or sympy.Mul object
     real : bool, optional
         Whether the expression is represented in a real orbital basis.
+        This will add the antisymmetric ERI and the fock matrix to
+        sym_tensors and rename complex t-amplitudes.
     sym_tensors: Iterable[str] | None, optional
         Names of tensors with bra-ket-symmetry, i.e.,
         d^{pq}_{rs} = d^{rs}_{pq}. Adjusts the corresponding tensors to
@@ -45,7 +47,7 @@ class ExprContainer(Container):
                  ) -> None:
         # import target index strings
         if target_idx is not None:
-            if isinstance(target_idx, str) or isinstance(target_idx, Sequence):
+            if isinstance(target_idx, Sequence):  # str, list, tuple
                 target_idx = get_symbols(target_idx)
             else:
                 target_tpl = tuple(target_idx)
@@ -54,32 +56,33 @@ class ExprContainer(Container):
                 target_idx = get_symbols(target_tpl)
                 del target_tpl
         # set the class attributes and import the inner expression
-        super().__init__(
-            inner=inner, real=real, sym_tensors=sym_tensors,
-            antisym_tensors=antisym_tensors, target_idx=target_idx
-        )
-        # ensure that sym_tensor and antisym_tensor are immutable tuples and
-        # remove duplicates
-        self._sym_tensors = tuple(sorted(set(self._sym_tensors)))
-        self._antisym_tensors = tuple(sorted(set(self._antisym_tensors)))
+        super().__init__(inner=inner, target_idx=target_idx)
         # Now apply the given assumptions: this only happens in this class
         # store target indices as sorted tuple
         if self._target_idx is not None:
             self.set_target_idx(self._target_idx)
-        # applying the tensor symmetry has a certain overlap with
-        # make_real: make_real will try to add ERI and Fock matrix
-        # to sym_tensor and apply the tensor symmetry (but only
-        # if the tensors were not already marked as symmetric).
-        # Therefore, it makes sense to manually add them here
-        # to avoid applying the tensor symmetry twice.
-        if self._sym_tensors or self._antisym_tensors:
-            if self._real:
-                self._sym_tensors = tuple(sorted(set(
-                    self._sym_tensors + (tensor_names.fock, tensor_names.eri)
-                )))
-            self._apply_tensor_braket_sym()
-        if self._real:
-            self.make_real(force=True)
+        # import sym and antisym_tensors
+        if isinstance(sym_tensors, str):
+            sym_tensors = (sym_tensors,)
+        elif not isinstance(sym_tensors, Sequence):
+            sym_tensors = tuple(sym_tensors)
+        if isinstance(antisym_tensors, str):
+            antisym_tensors = (antisym_tensors,)
+        elif not isinstance(antisym_tensors, Sequence):
+            antisym_tensors = tuple(antisym_tensors)
+        # we are working in a real orbital basis:
+        # rename complex tensors: for instance complex t-amplitudes t1cc -> t1
+        # add fock matrix and antisymmetric ERI to sym_tensors
+        if real:
+            sym_tensors = (*sym_tensors, tensor_names.fock, tensor_names.eri)
+            self._rename_complex_tensors()
+        # apply the tensor bra-ket-symmetry:
+        # real implicitly adds Fock and antisymmetric ERI to the
+        # symmetric tensors
+        if sym_tensors or antisym_tensors:
+            self._apply_tensor_braket_sym(
+                sym_tensors=sym_tensors, antisym_tensors=antisym_tensors
+            )
 
     def __len__(self) -> int:
         # ExprContainer(0) also has length 1!
@@ -136,101 +139,81 @@ class ExprContainer(Container):
                 sorted(set(get_symbols(target_idx)), key=sort_idx_canonical)
             )
 
-    @Container.sym_tensors.setter
-    def sym_tensors(self, tensors: Iterable[str]) -> None:
+    ############################################################
+    # Modify the expression (in place, related to assumptions) #
+    ############################################################
+    def add_bra_ket_sym(self, sym_tensors: Sequence[str] = tuple(),
+                        antisym_tensors: Sequence[str] = tuple()
+                        ) -> "ExprContainer":
         """
         Add bra-ket-symmetry to tensors according to their name.
-        Note that it is only formally possible to remove tensors from
-        sym_tensors, because the original state of a tensor is lost when the
-        bra-ket-symmetry is applied, i.e., after bra-ket-symmetry was added to
-        a tensor d^{p}_{q} it is not knwon whether it's original state was
-        d^{q}_{p} or d^{p}_{q}.
+        If "d" is given in sym_tensors: d^{pq}_{rs} = d^{rs}_{pq}.
+        If "d" is given in antisym_tensors: d^{pq}_{rs} = -d^{rs}_{pq}.
+        Note that it is not possible to remove bra-ket-symmetry,
+        because the original state of a tensor can not be recovered.
         """
-        if isinstance(tensors, str):
-            tensors = {tensors, }
-        else:
-            assert all(isinstance(t, str) for t in tensors)
-            tensors = set(tensors)
+        if isinstance(sym_tensors, str):
+            sym_tensors = (sym_tensors,)
+        if isinstance(antisym_tensors, str):
+            antisym_tensors = (antisym_tensors,)
 
-        if self.real:
-            tensors.update([tensor_names.fock, tensor_names.eri])
-        tensors = tuple(sorted(tensors))
-        if tensors != self._sym_tensors:
-            self._sym_tensors = tensors
-            self._apply_tensor_braket_sym()
+        return self._apply_tensor_braket_sym(
+            sym_tensors=sym_tensors, antisym_tensors=antisym_tensors
+        )
 
-    @Container.antisym_tensors.setter
-    def antisym_tensors(self, tensors: Iterable[str]) -> None:
+    def make_real(self) -> "ExprContainer":
         """
-        Add bra-ket-antisymmetry to tensors according to their name.
-        Note that it is only formally possible to remove tensors from
-        sym_tensors, because the original state of a tensor is lost when the
-        bra-ket-symmetry is applied, i.e., after bra-ket-antisymmetry was
-        added to a tensor d^{p}_{q} it is not knwon whether it's original
-        state was d^{q}_{p} or d^{p}_{q}.
+        Represent the expression in a real orbital basis.
+        - names of complex conjugate t-amplitudes, for instance t1cc -> t1
+        - adds bra-ket-symmetry to the fock matrix and the ERI.
         """
-        if isinstance(tensors, str):
-            tensors = (tensors,)
-        else:
-            assert all(isinstance(t, str) for t in tensors)
-            tensors = tuple(sorted(set(tensors)))
+        if self.inner.is_number:
+            return self
+        # add the bra-ket-symmetry:
+        self._apply_tensor_braket_sym(
+            sym_tensors=(tensor_names.fock, tensor_names.eri)
+        )
+        if self.inner.is_number:
+            return self
+        # rename the tensors and return
+        return self._rename_complex_tensors()
 
-        if tensors != self._antisym_tensors:
-            self._antisym_tensors = tensors
-            self._apply_tensor_braket_sym()
-
-    #################################################
-    # methods that modify the expression (in place) #
-    #################################################
-    def _apply_tensor_braket_sym(self) -> "ExprContainer":
+    def _apply_tensor_braket_sym(self, sym_tensors: Sequence[str] = tuple(),
+                                 antisym_tensors: Sequence[str] = tuple()
+                                 ) -> "ExprContainer":
         """
         Adds the bra-ket symmetry and antisymmetry defined in
         sym_tensors and antisym_tensors to the tensor objects
         in the expression.
         """
-        if self.inner.is_number:
+        if self.inner.is_number:  # nothing to do
             return self
-        # actually do something
         res = S.Zero
         for term in self.terms:
-            res += term._apply_tensor_braket_sym(wrap_result=False)
+            res += term._apply_tensor_braket_sym(
+                sym_tensors=sym_tensors, antisym_tensors=antisym_tensors,
+                wrap_result=False
+            )
         assert isinstance(res, Expr)
         self._inner = res
         return self
 
-    def make_real(self, force: bool = False) -> "ExprContainer":
+    def _rename_complex_tensors(self) -> "ExprContainer":
         """
-        Represent the expression in a real orbital basis.
-        - names of complex conjugate t-amplitudes, for instance t1cc -> t1
-        - adds bra-ket-symmetry to the fock matrix and the ERI.
-
-        Parameters
-        ----------
-        force: bool, optional
-            If set the function will also run also if 'real' is already set.
-            (default: False)
+        Renames complex tensors to reflect that the expression is
+        represented in a real orbital basis, e.g., complex t-amplitudes
+        are renamed t1cc -> t1.
         """
-        if (self.real and not force):
-            return self
-        # actually so something: first adjust the tensor symmetry
-        self._real = True
-        sym_tensors = self._sym_tensors
-        if tensor_names.fock not in sym_tensors or \
-                tensor_names.eri not in sym_tensors:
-            self._sym_tensors = tuple(sorted(set(
-                sym_tensors + (tensor_names.fock, tensor_names.eri)
-            )))
-            self._apply_tensor_braket_sym()
-        if self.inner.is_number:
-            return self
-        # and then adjust the tensor names
         res = S.Zero
         for term in self.terms:
-            res += term.make_real(wrap_result=False)
+            res += term._rename_complex_tensors(wrap_result=False)
         assert isinstance(res, Expr)
         self._inner = res
         return self
 
+    #################################################
+    # methods that modify the expression (in place) #
+    #################################################
     def block_diagonalize_fock(self) -> "ExprContainer":
         """
         Block diagonalize the Fock matrix, i.e. all terms that contain off
@@ -247,10 +230,10 @@ class ExprContainer(Container):
     def diagonalize_fock(self) -> "ExprContainer":
         """
         Represent the expression in the canonical orbital basis, where the
-        fock matrix is diagonal. Because it is not possible to
+        fock matrix is diagonal. Because it might not be possible to
         determine the target indices in the resulting expression according
         to the Einstein sum convention, the current target indices will
-        be set manually in the resulting expression.
+        be set in the resulting expression.
         """
         # expand to get rid of polynoms as much as possible
         self.expand()
@@ -264,7 +247,7 @@ class ExprContainer(Container):
         self._target_idx = diag.provided_target_idx
         return self
 
-    def rename_tensor(self, current: str, new: str) -> 'ExprContainer':
+    def rename_tensor(self, current: str, new: str) -> "ExprContainer":
         """Changes the name of a tensor from current to new."""
         assert isinstance(current, str) and isinstance(new, str)
 
@@ -275,7 +258,7 @@ class ExprContainer(Container):
         self._inner = renamed
         return self
 
-    def expand_antisym_eri(self) -> 'ExprContainer':
+    def expand_antisym_eri(self) -> "ExprContainer":
         """
         Expands the antisymmetric ERI using chemists notation
         <pq||rs> = (pr|qs) - (ps|qr).
@@ -287,14 +270,9 @@ class ExprContainer(Container):
             res += term.expand_antisym_eri(wrap_result=False)
         assert isinstance(res, Expr)
         self._inner = res
-        # only update the assumptions if there was an eri to expand
-        if Symbol(tensor_names.coulomb) in self.inner.atoms(Symbol):
-            self._sym_tensors = tuple(sorted(set(
-                self._sym_tensors + (tensor_names.coulomb,)
-            )))
         return self
 
-    def use_explicit_denominators(self) -> 'ExprContainer':
+    def use_explicit_denominators(self) -> "ExprContainer":
         """
         Switch to an explicit representation of orbital energy denominators by
         replacing all symbolic denominators by their explicit counter part,
@@ -305,15 +283,9 @@ class ExprContainer(Container):
             res += term.use_explicit_denominators(wrap_result=False)
         assert isinstance(res, Expr)
         self._inner = res
-        # remove the symbolic denom from the assumptions if necessary
-        if tensor_names.sym_orb_denom in self._antisym_tensors:
-            self._antisym_tensors = tuple(
-                t for t in self._antisym_tensors
-                if t != tensor_names.sym_orb_denom
-            )
         return self
 
-    def substitute_contracted(self) -> 'ExprContainer':
+    def substitute_contracted(self) -> "ExprContainer":
         """
         Tries to substitute all contracted indices with pretty indices, i.e.
         i, j, k instad of i3, n4, o42 etc.
@@ -327,7 +299,7 @@ class ExprContainer(Container):
         self._inner = res
         return self
 
-    def substitute_with_generic(self) -> 'ExprContainer':
+    def substitute_with_generic(self) -> "ExprContainer":
         """
         Subsitutes all contracted indices with new, unused generic indices.
         """
@@ -339,7 +311,7 @@ class ExprContainer(Container):
         self._inner = res
         return self
 
-    def factor(self, num=None) -> 'ExprContainer':
+    def factor(self, num=None) -> "ExprContainer":
         """
         Tries to factors the expression. Note: this only works for simple cases
 
@@ -363,7 +335,7 @@ class ExprContainer(Container):
         return self
 
     def expand_intermediates(self, fully_expand: bool = True
-                             ) -> 'ExprContainer':
+                             ) -> "ExprContainer":
         """
         Expand the known intermediates in the expression.
 
@@ -381,7 +353,9 @@ class ExprContainer(Container):
         # determine them after expanding intermediates
         expanded = S.Zero
         for t in self.terms:
-            expanded += t.expand_intermediates(fully_expand=fully_expand)
+            expanded += t.expand_intermediates(
+                fully_expand=fully_expand, wrap_result=True
+            )
         assert isinstance(expanded, ExprContainer)
         self._inner = expanded.inner
         self.set_target_idx(expanded.provided_target_idx)
@@ -394,22 +368,10 @@ class ExprContainer(Container):
         where D is a SymmetricTensor.
         """
         symbolic_denom = S.Zero
-        has_symbolic_denom = False
         for term in self.terms:
-            term = term.use_symbolic_denominators()
-            symbolic_denom += term.inner
-            if tensor_names.sym_orb_denom in term.antisym_tensors:
-                has_symbolic_denom = True
-        # the symbolic denominators have additional antisymmetry
-        # for bra ket swaps
-        # -> this is the only possible change in the assumptions
-        # -> only set if we replaced a denominator in the expr
+            symbolic_denom += term.use_symbolic_denominators(wrap_result=False)
         assert isinstance(symbolic_denom, Expr)
         self._inner = symbolic_denom
-        if has_symbolic_denom:
-            self._antisym_tensors = tuple(sorted(set(
-                self._antisym_tensors + (tensor_names.sym_orb_denom,)
-            )))
         return self
 
     ###########################################################

--- a/adcgen/expression/expr_container.py
+++ b/adcgen/expression/expr_container.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Sequence
 from typing import Any
 
-from sympy import Add, Basic, Expr, Mul, Pow, S, factor, nsimplify
+from sympy import Add, Expr, Mul, Pow, S, factor, nsimplify
 
 from ..indices import (
     Index, get_symbols, sort_idx_canonical,
@@ -347,7 +347,9 @@ class ExprContainer(Container):
         self._inner = res
         return self
 
-    def expand_intermediates(self, fully_expand: bool = True
+    def expand_intermediates(self, fully_expand: bool = True,
+                             braket_sym_tensors: Sequence[str] = tuple(),
+                             braket_antisym_tensors: Sequence[str] = tuple()
                              ) -> "ExprContainer":
         """
         Expand the known intermediates in the expression.
@@ -360,6 +362,12 @@ class ExprContainer(Container):
             False: The intermediates are only expanded once, e.g., n'th
               order MP t-amplitudes are expressed by means of (n-1)'th order
               MP t-amplitudes and ERI.
+        braket_sym_tensors: Sequence[str], optional
+            Add bra-ket-symmetry to the given tensors of the expanded
+            expression (after expansion of the intermediates).
+        braket_antisym_tensors: Sequence[str], optional
+            Add bra-ket-antisymmetry to the given tensors of the expanded
+            expression (after expansion of the intermediates).
         """
         # TODO: only expand specific intermediates
         # need to adjust the target indices -> not necessarily possible to
@@ -367,7 +375,9 @@ class ExprContainer(Container):
         expanded = S.Zero
         for t in self.terms:
             expanded += t.expand_intermediates(
-                fully_expand=fully_expand, wrap_result=True
+                fully_expand=fully_expand, wrap_result=True,
+                braket_sym_tensors=braket_sym_tensors,
+                braket_antisym_tensors=braket_antisym_tensors
             )
         assert isinstance(expanded, ExprContainer)
         self._inner = expanded.inner

--- a/adcgen/expression/normal_ordered_container.py
+++ b/adcgen/expression/normal_ordered_container.py
@@ -20,32 +20,16 @@ class NormalOrderedContainer(ObjectContainer):
     ----------
     inner:
         The NO object to wrap
-    real : bool, optional
-        Whether the expression is represented in a real orbital basis.
-    sym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-symmetry, i.e.,
-        d^{pq}_{rs} = d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional symmetry if they are not aware
-        of it yet.
-    antisym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-antisymmetry, i.e.,
-        d^{pq}_{rs} = - d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional antisymmetry if they are not
-        aware of it yet.
     target_idx: Iterable[Index] | None, optional
         Target indices of the expression. By default the Einstein sum
         convention will be used to identify target and contracted indices,
         which is not always sufficient.
     """
     def __init__(self, inner: Expr | Container | Any,
-                 real: bool = False,
-                 sym_tensors: Iterable[str] = tuple(),
-                 antisym_tensors: Iterable[str] = tuple(),
                  target_idx: Iterable[Index] | None = None) -> None:
         # call init from ObjectContainers parent class
         super(ObjectContainer, self).__init__(
-            inner=inner, real=real, sym_tensors=sym_tensors,
-            antisym_tensors=antisym_tensors, target_idx=target_idx
+            inner=inner, target_idx=target_idx
         )
         assert isinstance(self._inner, NO)
 

--- a/adcgen/expression/object_container.py
+++ b/adcgen/expression/object_container.py
@@ -31,18 +31,6 @@ class ObjectContainer(Container):
     ----------
     inner:
         The object to wrap, e.g., an AntiSymmetricTensor
-    real : bool, optional
-        Whether the expression is represented in a real orbital basis.
-    sym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-symmetry, i.e.,
-        d^{pq}_{rs} = d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional symmetry if they are not aware
-        of it yet.
-    antisym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-antisymmetry, i.e.,
-        d^{pq}_{rs} = - d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional antisymmetry if they are not
-        aware of it yet.
     target_idx: Iterable[Index] | None, optional
         Target indices of the expression. By default the Einstein sum
         convention will be used to identify target and contracted indices,
@@ -569,13 +557,14 @@ class ObjectContainer(Container):
     ###################################
     # methods manipulating the object #
     ###################################
-    def _apply_tensor_braket_sym(self, sym_tensors: Sequence[str] = tuple(),
-                                 antisym_tensors: Sequence[str] = tuple(),
-                                 wrap_result: bool = True
-                                 ) -> "ExprContainer | Expr":
+    def _apply_tensor_braket_sym(
+            self, braket_sym_tensors: Sequence[str] = tuple(),
+            braket_antisym_tensors: Sequence[str] = tuple(),
+            wrap_result: bool = True) -> "ExprContainer | Expr":
         """
-        Applies the bra-ket symmetry defined in sym_tensors and antisym_tensors
-        to the current object. If wrap_result is set, the new object will be
+        Applies the bra-ket symmetry defined in braket_sym_tensors and
+        braket_antisym_tensors to the current object.
+        If wrap_result is set, the new object will be
         wrapped by :py:class:`ExprContainer`.
         """
         from .expr_container import ExprContainer
@@ -585,9 +574,9 @@ class ObjectContainer(Container):
         if isinstance(base, AntiSymmetricTensor):
             name = base.name
             braketsym: None | Number = None
-            if name in sym_tensors and base.bra_ket_sym is not S.One:
+            if name in braket_sym_tensors and base.bra_ket_sym is not S.One:
                 braketsym = S.One
-            elif name in antisym_tensors and \
+            elif name in braket_antisym_tensors and \
                     base.bra_ket_sym is not S.NegativeOne:
                 braketsym = S.NegativeOne
             if braketsym is not None:

--- a/adcgen/expression/polynom_container.py
+++ b/adcgen/expression/polynom_container.py
@@ -2,10 +2,9 @@ from collections.abc import Iterable, Sequence
 from functools import cached_property
 from typing import Any, TYPE_CHECKING
 
-from sympy import Add, Expr, Pow, Symbol, S
+from sympy import Add, Expr, Pow, S
 
 from ..indices import Index, sort_idx_canonical
-from ..tensor_names import tensor_names
 from .container import Container
 from .object_container import ObjectContainer
 
@@ -23,32 +22,16 @@ class PolynomContainer(ObjectContainer):
     ----------
     inner:
         The polynom to wrap
-    real : bool, optional
-        Whether the expression is represented in a real orbital basis.
-    sym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-symmetry, i.e.,
-        d^{pq}_{rs} = d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional symmetry if they are not aware
-        of it yet.
-    antisym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-antisymmetry, i.e.,
-        d^{pq}_{rs} = - d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional antisymmetry if they are not
-        aware of it yet.
     target_idx: Iterable[Index] | None, optional
         Target indices of the expression. By default the Einstein sum
         convention will be used to identify target and contracted indices,
         which is not always sufficient.
     """
     def __init__(self, inner: Expr | Container | Any,
-                 real: bool = False,
-                 sym_tensors: Iterable[str] = tuple(),
-                 antisym_tensors: Iterable[str] = tuple(),
                  target_idx: Iterable[Index] | None = None) -> None:
         # call init from ObjectContainers parent class
         super(ObjectContainer, self).__init__(
-            inner=inner, real=real, sym_tensors=sym_tensors,
-            antisym_tensors=antisym_tensors, target_idx=target_idx
+            inner=inner, target_idx=target_idx
         )
         if isinstance(self._inner, Pow):
             assert isinstance(self._inner.args[0], Add)
@@ -112,7 +95,9 @@ class PolynomContainer(ObjectContainer):
     ####################################
     # methods manipulating the polynom #
     ####################################
-    def _apply_tensor_braket_sym(self, wrap_result: bool = True
+    def _apply_tensor_braket_sym(self, sym_tensors: Sequence[str] = tuple(),
+                                 antisym_tensors: Sequence[str] = tuple(),
+                                 wrap_result: bool = True
                                  ) -> "ExprContainer | Expr":
         """
         Applies the tensor bra-ket symmetry defined in sym_tensors and
@@ -123,7 +108,10 @@ class PolynomContainer(ObjectContainer):
 
         with_sym = S.Zero
         for term in self.terms:
-            with_sym += term._apply_tensor_braket_sym(wrap_result=False)
+            with_sym += term._apply_tensor_braket_sym(
+                sym_tensors=sym_tensors, antisym_tensors=antisym_tensors,
+                wrap_result=False
+            )
         assert isinstance(with_sym, Expr)
         with_sym = Pow(with_sym, self.exponent)
 
@@ -131,30 +119,30 @@ class PolynomContainer(ObjectContainer):
             with_sym = ExprContainer(inner=with_sym, **self.assumptions)
         return with_sym
 
-    def make_real(self, wrap_result: bool = True) -> "ExprContainer | Expr":
+    def _rename_complex_tensors(self, wrap_result: bool = True
+                                ) -> "ExprContainer | Expr":
         """
-        Represent the polynom in a real orbital basis.
-        - names of complex conjugate t-amplitudes, for instance t1cc -> t1
-        - adds bra-ket-symmetry to the fock matrix and the ERI.
+        Renames complex tensors to reflect that the expression is
+        represented in a real orbital basis, e.g., complex t-amplitudes
+        are renamed t1cc -> t1.
 
         Parameters
         ----------
-        wrap_result : bool, optional
-            If set the result will be wrapped with an
-            :py:class:`ExprContainer`. (default: True)
+        wrap_result: bool, optional
+            If set the result will be wrapped with
+            :py:class:`ExprContainer`. Otherwise the unwrapped
+            object is returned. (default: True)
         """
         from .expr_container import ExprContainer
 
         real = S.Zero
         for term in self.terms:
-            real += term.make_real(wrap_result=False)
+            real += term._rename_complex_tensors(wrap_result=False)
         assert isinstance(real, Expr)
         real = Pow(real, self.exponent)
 
         if wrap_result:
-            assumptions = self.assumptions
-            assumptions["real"] = True
-            real = ExprContainer(inner=real, **assumptions)
+            real = ExprContainer(inner=real, **self.assumptions)
         return real
 
     def block_diagonalize_fock(self, wrap_result: bool = True
@@ -215,11 +203,7 @@ class PolynomContainer(ObjectContainer):
         expanded = Pow(expanded, self.exponent)
 
         if wrap_result:
-            assumptions = self.assumptions
-            # add the coulomb tensor to sym_tensors if necessary
-            if Symbol(tensor_names.coulomb) in expanded.atoms(Symbol):
-                assumptions["sym_tensors"] += (tensor_names.coulomb,)
-            expanded = ExprContainer(inner=expanded, **assumptions)
+            expanded = ExprContainer(inner=expanded, **self.assumptions)
         return expanded
 
     def expand_intermediates(self, target: Sequence[Index],
@@ -259,13 +243,9 @@ class PolynomContainer(ObjectContainer):
         explicit_denom = Pow(explicit_denom, self.exponent)
 
         if wrap_result:
-            assumptions = self.assumptions
-            if tensor_names.sym_orb_denom in self.antisym_tensors:
-                assumptions["antisym_tensors"] = tuple(
-                    n for n in assumptions["antisym_tensors"]
-                    if n != tensor_names.sym_orb_denom
-                )
-            explicit_denom = ExprContainer(inner=explicit_denom, **assumptions)
+            explicit_denom = ExprContainer(
+                inner=explicit_denom, **self.assumptions
+            )
         return explicit_denom
 
     def to_latex_str(self, only_pull_out_pref: bool = False,

--- a/adcgen/expression/polynom_container.py
+++ b/adcgen/expression/polynom_container.py
@@ -95,13 +95,14 @@ class PolynomContainer(ObjectContainer):
     ####################################
     # methods manipulating the polynom #
     ####################################
-    def _apply_tensor_braket_sym(self, sym_tensors: Sequence[str] = tuple(),
-                                 antisym_tensors: Sequence[str] = tuple(),
-                                 wrap_result: bool = True
-                                 ) -> "ExprContainer | Expr":
+    def _apply_tensor_braket_sym(
+            self, braket_sym_tensors: Sequence[str] = tuple(),
+            braket_antisym_tensors: Sequence[str] = tuple(),
+            wrap_result: bool = True) -> "ExprContainer | Expr":
         """
-        Applies the tensor bra-ket symmetry defined in sym_tensors and
-        antisym_tensors to all tensors in the polynom. If wrap_result is set,
+        Applies the tensor bra-ket symmetry defined in braket_sym_tensors and
+        braket_antisym_tensors to all tensors in the polynom.
+        If wrap_result is set,
         the new term will be wrapped by :py:class:`ExprContainer`.
         """
         from .expr_container import ExprContainer
@@ -109,7 +110,8 @@ class PolynomContainer(ObjectContainer):
         with_sym = S.Zero
         for term in self.terms:
             with_sym += term._apply_tensor_braket_sym(
-                sym_tensors=sym_tensors, antisym_tensors=antisym_tensors,
+                braket_sym_tensors=braket_sym_tensors,
+                braket_antisym_tensors=braket_antisym_tensors,
                 wrap_result=False
             )
         assert isinstance(with_sym, Expr)

--- a/adcgen/expression/polynom_container.py
+++ b/adcgen/expression/polynom_container.py
@@ -210,7 +210,9 @@ class PolynomContainer(ObjectContainer):
 
     def expand_intermediates(self, target: Sequence[Index],
                              wrap_result: bool = True,
-                             fully_expand: bool = True
+                             fully_expand: bool = True,
+                             braket_sym_tensors: Sequence[str] = tuple(),
+                             braket_antisym_tensors: Sequence[str] = tuple()
                              ) -> "ExprContainer | Expr":
         """Expands all known intermediates in the polynom."""
         from .expr_container import ExprContainer
@@ -218,7 +220,9 @@ class PolynomContainer(ObjectContainer):
         expanded = S.Zero
         for term in self.terms:
             expanded += term.expand_intermediates(
-                target, wrap_result=False, fully_expand=fully_expand
+                target, wrap_result=False, fully_expand=fully_expand,
+                braket_sym_tensors=braket_sym_tensors,
+                braket_antisym_tensors=braket_antisym_tensors
             )
         assert isinstance(expanded, Expr)
         expanded = Pow(expanded, self.exponent)

--- a/adcgen/expression/term_container.py
+++ b/adcgen/expression/term_container.py
@@ -339,13 +339,14 @@ class TermContainer(Container):
     ###############################
     # method that modify the term #
     ###############################
-    def _apply_tensor_braket_sym(self, sym_tensors: Sequence[str] = tuple(),
-                                 antisym_tensors: Sequence[str] = tuple(),
-                                 wrap_result: bool = True
-                                 ) -> "ExprContainer | Expr":
+    def _apply_tensor_braket_sym(
+            self, braket_sym_tensors: Sequence[str] = tuple(),
+            braket_antisym_tensors: Sequence[str] = tuple(),
+            wrap_result: bool = True) -> "ExprContainer | Expr":
         """
-        Applies the tensor bra-ket symmetry defined in sym_tensors and
-        antisym_tensors to all tensors in the term. If wrap_result is set,
+        Applies the tensor bra-ket symmetry defined in braket_sym_tensors and
+        braket_antisym_tensors to all tensors in the term.
+        If wrap_result is set,
         the new term will be wrapped by :py:class:`ExprContainer`.
         """
         from .expr_container import ExprContainer
@@ -353,7 +354,8 @@ class TermContainer(Container):
         term = S.One
         for obj in self.objects:
             term *= obj._apply_tensor_braket_sym(
-                sym_tensors=sym_tensors, antisym_tensors=antisym_tensors,
+                braket_sym_tensors=braket_sym_tensors,
+                braket_antisym_tensors=braket_antisym_tensors,
                 wrap_result=False
             )
         assert isinstance(term, Expr)

--- a/adcgen/expression/term_container.py
+++ b/adcgen/expression/term_container.py
@@ -3,7 +3,7 @@ from collections import Counter
 from functools import cached_property
 from typing import Any, TYPE_CHECKING, Sequence
 
-from sympy import Add, Expr, Mul, Pow, S, Symbol, factor, latex, nsimplify
+from sympy import Add, Expr, Mul, Pow, S, factor, latex, nsimplify
 from sympy.physics.secondquant import NO
 
 from ..indices import (
@@ -12,7 +12,6 @@ from ..indices import (
 )
 from ..misc import Inputerror, cached_member
 from ..sympy_objects import NonSymmetricTensor
-from ..tensor_names import tensor_names
 from .container import Container
 from .normal_ordered_container import NormalOrderedContainer
 from .polynom_container import PolynomContainer
@@ -32,18 +31,6 @@ class TermContainer(Container):
     ----------
     inner:
         The algebraic term to wrap, e.g., a sympy.Mul object
-    real : bool, optional
-        Whether the expression is represented in a real orbital basis.
-    sym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-symmetry, i.e.,
-        d^{pq}_{rs} = d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional symmetry if they are not aware
-        of it yet.
-    antisym_tensors: Iterable[str] | None, optional
-        Names of tensors with bra-ket-antisymmetry, i.e.,
-        d^{pq}_{rs} = - d^{rs}_{pq}. Adjusts the corresponding tensors to
-        correctly represent this additional antisymmetry if they are not
-        aware of it yet.
     target_idx: Iterable[Index] | None, optional
         Target indices of the expression. By default the Einstein sum
         convention will be used to identify target and contracted indices,
@@ -51,14 +38,8 @@ class TermContainer(Container):
     """
 
     def __init__(self, inner: Expr | Container | Any,
-                 real: bool = False,
-                 sym_tensors: Iterable[str] = tuple(),
-                 antisym_tensors: Iterable[str] = tuple(),
                  target_idx: Iterable[Index] | None = None) -> None:
-        super().__init__(
-            inner=inner, real=real, sym_tensors=sym_tensors,
-            antisym_tensors=antisym_tensors, target_idx=target_idx
-        )
+        super().__init__(inner=inner, target_idx=target_idx)
         # we can not wrap an Add object: should be wrapped by ExprContainer
         # But everything else should be fine (Mul or single objects)
         assert not isinstance(self._inner, Add)
@@ -358,7 +339,9 @@ class TermContainer(Container):
     ###############################
     # method that modify the term #
     ###############################
-    def _apply_tensor_braket_sym(self, wrap_result: bool = True
+    def _apply_tensor_braket_sym(self, sym_tensors: Sequence[str] = tuple(),
+                                 antisym_tensors: Sequence[str] = tuple(),
+                                 wrap_result: bool = True
                                  ) -> "ExprContainer | Expr":
         """
         Applies the tensor bra-ket symmetry defined in sym_tensors and
@@ -369,35 +352,37 @@ class TermContainer(Container):
 
         term = S.One
         for obj in self.objects:
-            term *= obj._apply_tensor_braket_sym(wrap_result=False)
+            term *= obj._apply_tensor_braket_sym(
+                sym_tensors=sym_tensors, antisym_tensors=antisym_tensors,
+                wrap_result=False
+            )
+        assert isinstance(term, Expr)
         if wrap_result:
             term = ExprContainer(inner=term, **self.assumptions)
         return term
 
-    def make_real(self, wrap_result: bool = True) -> "ExprContainer | Expr":
+    def _rename_complex_tensors(self, wrap_result: bool = True
+                                ) -> "ExprContainer | Expr":
         """
-        Represent the tern in a real orbital basis.
-        - names of complex conjugate t-amplitudes, for instance t1cc -> t1
-        - adds bra-ket-symmetry to the fock matrix and the ERI.
+        Renames complex tensors to reflect that the expression is
+        represented in a real orbital basis, e.g., complex t-amplitudes
+        are renamed t1cc -> t1.
 
         Parameters
         ----------
         wrap_result: bool, optional
-            If this is set the result will be wrapped in an
-            :py:class:`ExprContainer`. Otherwhise that unwrapped object
-            is returned. (default: True)
+            If set the result will be wrapped with
+            :py:class:`ExprContainer`. Otherwise the unwrapped
+            object is returned. (default: True)
         """
         from .expr_container import ExprContainer
 
-        real_term = S.One
+        res = S.One
         for obj in self.objects:
-            real_term *= obj.make_real(wrap_result=False)
-
+            res *= obj._rename_complex_tensors(wrap_result=False)
         if wrap_result:
-            kwargs = self.assumptions
-            kwargs["real"] = True
-            real_term = ExprContainer(inner=real_term, **kwargs)
-        return real_term
+            res = ExprContainer(inner=res, **self.assumptions)
+        return res
 
     def block_diagonalize_fock(self, wrap_result: bool = True
                                ) -> "ExprContainer | Expr":
@@ -612,10 +597,7 @@ class TermContainer(Container):
             expanded *= obj.expand_antisym_eri(wrap_result=False)
 
         if wrap_result:
-            assumptions = self.assumptions
-            if Symbol(tensor_names.coulomb) in expanded.atoms(Symbol):
-                assumptions["sym_tensors"] += (tensor_names.coulomb,)
-            expanded = ExprContainer(expanded, **assumptions)
+            expanded = ExprContainer(expanded, **self.assumptions)
         return expanded
 
     def expand_intermediates(self, target: Sequence[Index] | None = None,
@@ -684,14 +666,7 @@ class TermContainer(Container):
             explicit_denom *= obj.use_explicit_denominators(wrap_result=False)
 
         if wrap_result:
-            assumptions = self.assumptions
-            # remove the tensor from the assumptions
-            if tensor_names.sym_orb_denom in self.antisym_tensors:
-                assumptions["antisym_tensors"] = tuple(
-                    n for n in assumptions["antisym_tensors"]
-                    if n != tensor_names.sym_orb_denom
-                )
-            explicit_denom = ExprContainer(explicit_denom, **assumptions)
+            explicit_denom = ExprContainer(explicit_denom, **self.assumptions)
         return explicit_denom
 
     def split_orb_energy(self) -> "dict[str, ExprContainer]":
@@ -706,10 +681,10 @@ class TermContainer(Container):
         from .expr_container import ExprContainer
 
         assumptions = self.assumptions
-        assumptions['target_idx'] = self.target
+        assumptions["target_idx"] = self.target
         ret = {"num": ExprContainer(1, **assumptions),
-               'denom': ExprContainer(1, **assumptions),
-               'remainder': ExprContainer(1, **assumptions)}
+               "denom": ExprContainer(1, **assumptions),
+               "remainder": ExprContainer(1, **assumptions)}
         for o in self.objects:
             base, exponent = o.base_and_exponent
             if o.inner.is_number:
@@ -717,21 +692,26 @@ class TermContainer(Container):
             elif o.contains_only_orb_energies:
                 key = "denom" if exponent < S.Zero else "num"
             else:
-                key = 'remainder'
+                key = "remainder"
             ret[key] *= Pow(base, abs(exponent))
         return ret
 
-    def use_symbolic_denominators(self) -> "ExprContainer":
+    def use_symbolic_denominators(self, wrap_result: bool = True
+                                  ) -> "ExprContainer | Expr":
         """
         Replace all orbital energy denominators in the expression by tensors,
         e.g., (e_a + e_b - e_i - e_j)^{-1} will be replaced by D^{ab}_{ij},
-        where D is a SymmetricTensor."""
+        where D is a SymmetricTensor.
+        """
         from ..eri_orbenergy import EriOrbenergy
 
         term = EriOrbenergy(self)
         symbolic_denom = term.symbolic_denominator()
-        # symbolic denom might additionaly have D set as antisym tensor
-        return symbolic_denom * term.pref * term.num.inner * term.eri.inner
+        if wrap_result:
+            return term.pref * symbolic_denom * term.num * term.eri
+        return (
+            term.pref * symbolic_denom.inner * term.num.inner * term.eri.inner
+        )
 
     def to_latex_str(self, only_pull_out_pref: bool = False,
                      spin_as_overbar: bool = False):

--- a/adcgen/expression/term_container.py
+++ b/adcgen/expression/term_container.py
@@ -604,7 +604,9 @@ class TermContainer(Container):
 
     def expand_intermediates(self, target: Sequence[Index] | None = None,
                              wrap_result: bool = True,
-                             fully_expand: bool = True
+                             fully_expand: bool = True,
+                             braket_sym_tensors: Sequence[str] = tuple(),
+                             braket_antisym_tensors: Sequence[str] = tuple()
                              ) -> "ExprContainer | Expr":
         """
         Expands all known intermediates in the term.
@@ -626,6 +628,12 @@ class TermContainer(Container):
             False: The intermediates are only expanded once, e.g., n'th
               order MP t-amplitudes are expressed by means of (n-1)'th order
               MP t-amplitudes and ERI.
+        braket_sym_tensors: Sequence[str], optional
+            Add bra-ket-symmetry to the given tensors of the expanded
+            expression (after expansion of the intermediates).
+        braket_antisym_tensors: Sequence[str], optional
+            Add bra-ket-antisymmetry to the given tensors of the expanded
+            expression (after expansion of the intermediates).
         """
         from .expr_container import ExprContainer
 
@@ -635,7 +643,9 @@ class TermContainer(Container):
         expanded = S.One
         for obj in self.objects:
             expanded *= obj.expand_intermediates(
-                target, wrap_result=False, fully_expand=fully_expand
+                target, wrap_result=False, fully_expand=fully_expand,
+                braket_sym_tensors=braket_sym_tensors,
+                braket_antisym_tensors=braket_antisym_tensors
             )
 
         if wrap_result:

--- a/adcgen/factor_intermediates.py
+++ b/adcgen/factor_intermediates.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable, Sequence, Generator
 from collections import Counter
 from functools import cached_property
+from time import perf_counter
 from typing import Any, TYPE_CHECKING, TypeGuard
 import itertools
 
@@ -48,7 +49,6 @@ def factor_intermediates(expr: ExprContainer,
         might be reduced which is not correctly handled currently.
     """
     from .intermediates import Intermediates, RegisteredIntermediate
-    from time import perf_counter
 
     assert isinstance(expr, ExprContainer)
     if expr.inner.is_number:  # nothing to factor

--- a/adcgen/intermediates.py
+++ b/adcgen/intermediates.py
@@ -238,13 +238,7 @@ class RegisteredIntermediate:
         # build the tensor object
         tensor = self._build_tensor(indices=indices)
         if wrap_result:
-            kwargs = {}
-            if isinstance(tensor, AntiSymmetricTensor):
-                if tensor.bra_ket_sym is S.One:  # bra ket symmetry
-                    kwargs["sym_tensors"] = (tensor.name,)
-                elif tensor.bra_ket_sym is S.NegativeOne:  # bra ket anisym
-                    kwargs["antisym_tensors"] = (tensor.name,)
-            return ExprContainer(tensor, **kwargs)
+            return ExprContainer(tensor)
         else:
             return tensor
 

--- a/adcgen/intermediates.py
+++ b/adcgen/intermediates.py
@@ -426,10 +426,6 @@ class RegisteredIntermediate:
         )
 
         assert isinstance(expr, ExprContainer)
-        if not expr.real:
-            raise NotImplementedError("Intermediates only implemented for "
-                                      "a real orbital basis.")
-
         # ensure that the previously factored intermediates
         # are provided as tuple -> can use them as dict key
         if isinstance(factored_itmds, str):
@@ -549,9 +545,6 @@ class t2_1(RegisteredIntermediate):
         """
         _ = allow_repeated_itmd_indices
         assert isinstance(expr, ExprContainer)
-        if not expr.real:
-            raise NotImplementedError("Intermediates only implemented for a "
-                                      "real orbital basis.")
         # do we have something to factor? did we already factor the itmd?
         if expr.inner.is_number or \
                 (factored_itmds and self.name in factored_itmds):

--- a/adcgen/reduce_expr.py
+++ b/adcgen/reduce_expr.py
@@ -48,7 +48,7 @@ def reduce_expr(expr: ExprContainer) -> ExprContainer:
             braket_sym_tensors=braket_sym_tensors
         )
         assert isinstance(term, ExprContainer)
-        term = term.expand().make_real()
+        term = term.expand()
         logger.info(f"into {len(term)} terms.\nCollecting terms.... ")
         term = factor_eri_parts(term)
         logger.info('-'*80)

--- a/adcgen/reduce_expr.py
+++ b/adcgen/reduce_expr.py
@@ -21,9 +21,6 @@ def reduce_expr(expr: ExprContainer) -> ExprContainer:
     The implementation assumes a real orbital basis.
     """
     assert isinstance(expr, ExprContainer)
-    if not expr.real:
-        raise NotImplementedError("Intermediates only implemented for a real "
-                                  "orbital basis.")
     expr = expr.expand()
 
     # check if we have anything to do

--- a/adcgen/reduce_expr.py
+++ b/adcgen/reduce_expr.py
@@ -10,6 +10,7 @@ from .expression import ExprContainer, TermContainer
 from .indices import Index
 from .logger import logger
 from .symmetry import Permutation
+from .tensor_names import tensor_names
 
 
 def reduce_expr(expr: ExprContainer) -> ExprContainer:
@@ -27,6 +28,9 @@ def reduce_expr(expr: ExprContainer) -> ExprContainer:
     if expr.inner.is_number:
         return expr
 
+    # add eri and fock matrix to the sym_tensors
+    braket_sym_tensors = (tensor_names.fock, tensor_names.eri)
+
     logger.info("".join(
         ['\n', '#'*80, '\n', ' '*25, "REDUCING EXPRESSION\n", '#'*80, '\n']
     ))
@@ -39,9 +43,12 @@ def reduce_expr(expr: ExprContainer) -> ExprContainer:
     for term_i, term in enumerate(expr.terms):
         logger.info(
             "#"*80 + f"\nExpanding term {term_i+1} of {len(expr)}: {term}... ")
-        term = term.expand_intermediates()
+        term = term.expand_intermediates(
+            wrap_result=True, fully_expand=True,
+            braket_sym_tensors=braket_sym_tensors
+        )
         assert isinstance(term, ExprContainer)
-        term = term.expand()
+        term = term.expand().make_real()
         logger.info(f"into {len(term)} terms.\nCollecting terms.... ")
         term = factor_eri_parts(term)
         logger.info('-'*80)

--- a/adcgen/sympy_objects.py
+++ b/adcgen/sympy_objects.py
@@ -333,12 +333,13 @@ class KroneckerDelta(DefinedFunction):
             return cls(j, i)
         return None
 
-    def _eval_power(self, exp) -> Expr:  # type: ignore[override]
+    def _eval_power(self, exp) -> Expr | None:  # type: ignore[override]
         # we don't want exponents > 1 on deltas!
         if exp.is_positive:
             return self
         elif exp.is_negative and exp is not S.NegativeOne:
             return S.One / self
+        return None
 
     def _latex(self, printer) -> str:
         return (

--- a/examples/mp2_density.py
+++ b/examples/mp2_density.py
@@ -10,7 +10,9 @@ mp = GroundState(h)
 expec = mp.expectation_value(order=2, n_particles=1)
 # in a real orbital basis and for a symmetric operator matrix as the density
 # is symmetric.
-expec = ExprContainer(expec, real=True, sym_tensors=[tensor_names.operator])
+expec = ExprContainer(
+    expec, real=True, braket_sym_tensors=[tensor_names.operator]
+)
 expec.substitute_contracted()
 expec = simplify(expec)
 

--- a/examples/pp_adc2_state_diffdm.py
+++ b/examples/pp_adc2_state_diffdm.py
@@ -16,7 +16,9 @@ expec = prop.expectation_value(adc_order=2, n_particles=1)
 # Add assumptions:
 # - real orbital basis
 # - a symmetric operator matrix d (with bra-ket-symmetry)
-expec = ExprContainer(expec, real=True, sym_tensors=[tensor_names.operator])
+expec = ExprContainer(
+    expec, real=True, braket_sym_tensors=[tensor_names.operator]
+)
 # for the state_diff_dm we have the same eigenvector in the bra (X) and ket (Y)
 expec.rename_tensor(current=tensor_names.left_adc_amplitude,
                     new=tensor_names.right_adc_amplitude)

--- a/examples/remp_residuals.py
+++ b/examples/remp_residuals.py
@@ -22,7 +22,7 @@ re_residual = re.amplitude_residual(order=order, space=space, indices=indices)
 remp_A = Symbol("A")
 
 # build and simplify the remp residual (assuming a real orbital basis)
-remp_residual = remp_A * mp_residual + (1 - remp_A) * re_residual  # type: ignore  # noqa E501
+remp_residual = remp_A * mp_residual + (1 - remp_A) * re_residual
 remp_residual = ExprContainer(remp_residual, real=True)
 remp_residual.substitute_contracted()
 remp_residual = simplify(remp_residual)

--- a/tests/core_valence_separation_test.py
+++ b/tests/core_valence_separation_test.py
@@ -139,8 +139,10 @@ class TestCoreValenceSeparation:
         m_contribs = ref_data["real_factored"]
         m_expr = sum(m_contribs.values())
         assert isinstance(m_expr, ExprContainer)
+        # sym_tensors: fine through third order
+        sym_tensors = ("p2", "t2sq")
         m_expr.make_real()
-        m_expr.sym_tensors = ("p2", "t2sq")  # fine through 3rd order
+        m_expr.add_bra_ket_sym(braket_sym_tensors=sym_tensors)
         # build the valence-valence block (no core orbitals)
         res = apply_cvs_approximation(m_expr.copy(), "")
         assert simplify(res - m_expr).inner is S.Zero
@@ -154,5 +156,7 @@ class TestCoreValenceSeparation:
         res = apply_cvs_approximation(m_expr.copy(), "IJ")
         for delta_sp, sub_expr in sort.by_delta_types(res).items():
             ref = ref_data["real_factored_cvs"]["-".join(delta_sp)]
-            ref = ExprContainer(ref.inner, **sub_expr.assumptions)
+            assert isinstance(ref, ExprContainer)
+            ref.make_real()
+            ref.add_bra_ket_sym(braket_sym_tensors=sym_tensors)
             assert simplify(sub_expr - ref).inner is S.Zero

--- a/tests/groundstate_test.py
+++ b/tests/groundstate_test.py
@@ -110,19 +110,24 @@ class TestGroundState():
         # assume a real basis and a symmetric operator/ symmetric dm
         expec.substitute_contracted()
         expec.make_real()
-        expec.sym_tensors = [tensor_names.operator]
+        expec.add_bra_ket_sym(braket_sym_tensors=tensor_names.operator)
         expec = simplify(expec)
         ref_expec = ref['real_symmetric_expectation_value']
-        assert simplify(expec - ref_expec.inner).inner is S.Zero
+        assert isinstance(ref_expec, ExprContainer)
+        ref_expec.make_real()
+        ref_expec.add_bra_ket_sym(braket_sym_tensors=(tensor_names.operator,))
+        assert simplify(expec - ref_expec).inner is S.Zero
 
         # extract all blocks of the symmetric dm
         density_matrix = remove_tensor(expec, tensor_names.operator)
         for block, block_expr in density_matrix.items():
             assert len(block) == 1
             ref_dm = ref["real_symmetric_dm"][block[0]]
-            assert simplify(block_expr - ref_dm.inner).inner is S.Zero
+            assert isinstance(ref_dm, ExprContainer)
+            ref_dm.make_real()
+            assert simplify(block_expr - ref_dm).inner is S.Zero
 
-            # exploit permutational symmetry and collec the terms again
+            # exploit permutational symmetry and collect the terms again
             re_expanded_dm = ExprContainer(0, **block_expr.assumptions)
             for perm_sym, sub_expr in \
                     sort.exploit_perm_sym(block_expr).items():

--- a/tests/reference_data/generate_data.py
+++ b/tests/reference_data/generate_data.py
@@ -149,7 +149,9 @@ class Generator:
                     dump["expectation_value"] = str(res)
                     # dump the real symmetric expec value
                     res.make_real()
-                    res.sym_tensors = [tensor_names.operator]
+                    res.add_bra_ket_sym(
+                        braket_sym_tensors=tensor_names.operator
+                    )
                     res = simplify(res)
                     dump["real_symmetric_expectation_value"] = str(res)
                     # dump the real symmetric density matrix
@@ -303,7 +305,9 @@ class Generator:
                     # dump the real result for a symmetric operator
                     # for a single state
                     res.make_real()
-                    res.sym_tensors = [tensor_names.operator]
+                    res.add_bra_ket_sym(
+                        braket_sym_tensors=tensor_names.operator
+                    )
                     res.rename_tensor(tensor_names.left_adc_amplitude,
                                       tensor_names.right_adc_amplitude)
                     res = simplify(res)

--- a/tests/secular_matrix_test.py
+++ b/tests/secular_matrix_test.py
@@ -10,24 +10,24 @@ from sympy import S
 import pytest
 
 
-@pytest.mark.parametrize('order', [0, 1, 2, 3])
+@pytest.mark.parametrize("order", [0, 1, 2, 3])
 class TestSecularMatrix():
-    @pytest.mark.parametrize('block,indices',
-                             [('ph,ph', 'ia,jb')])
+    @pytest.mark.parametrize("block,indices",
+                             [("ph,ph", "ia,jb")])
     def test_isr_matrix_block(self, order, block, indices, cls_instances,
                               reference_data):
         # load reference data
         ref = reference_data["secular_matrix"]["pp"][block][order]
 
         # compute the raw matrix block
-        m = cls_instances['mp']['m'].isr_matrix_block(order, block, indices)
+        m = cls_instances["mp"]["m"].isr_matrix_block(order, block, indices)
         m = ExprContainer(m)
         ref_m = ref["complex"]
         assert simplify(m - ref_m).inner is S.Zero
 
         # assume a real orbital basis
         m = ExprContainer(m.inner, real=True).substitute_contracted()
-        ref_m = ref['real'].make_real()
+        ref_m = ref["real"].make_real()
         assert simplify(m - ref_m).inner is S.Zero
 
         # expand itmds, cancel orbital energy fractions
@@ -47,8 +47,11 @@ class TestSecularMatrix():
         for delta_sp, sub_expr in sort.by_delta_types(m).items():
             # compare to reference
             ref_sub_expr = ref["real_factored"]["-".join(delta_sp)]
-            ref_sub_expr = ExprContainer(
-                ref_sub_expr.inner, **sub_expr.assumptions
+            ref_sub_expr = ExprContainer(ref_sub_expr, **sub_expr.assumptions)
+            ref_sub_expr.make_real()
+            ref_sub_expr.add_bra_ket_sym(
+                braket_sym_tensors=sub_expr.braket_sym_tensors,
+                braket_antisym_tensors=sub_expr.braket_antisym_tensors
             )
             assert simplify(sub_expr - ref_sub_expr).inner is S.Zero
             # exploit permutational symmetry and test that the result is

--- a/tests/spatial_orbitals_test.py
+++ b/tests/spatial_orbitals_test.py
@@ -295,21 +295,21 @@ class TestTransformToSpatialOrbitals:
         i, j, k, a, b, c = get_symbols("ijkabc", "aaaaaa")
         jb, kb, bb = get_symbols("jkb", "bbb")
         ref = (
-            SymmetricTensor(tensor_names.sym_orb_denom, (b, c), (i, j), -1) *  # type: ignore  # noqa E501
-            SymmetricTensor(tensor_names.coulomb, (j, b), (a, c), 1) * (  # type: ignore  # noqa E501
+            SymmetricTensor(tensor_names.sym_orb_denom, (b, c), (i, j), -1) *
+            SymmetricTensor(tensor_names.coulomb, (j, b), (a, c), 1) * (
                 SymmetricTensor(tensor_names.coulomb, (i, b), (j, c), 1)
                 - SymmetricTensor(tensor_names.coulomb, (i, c), (j, b), 1)
             )
-            - SymmetricTensor(tensor_names.sym_orb_denom, (bb, c), (i, jb),  # type: ignore  # noqa E501
+            - SymmetricTensor(tensor_names.sym_orb_denom, (bb, c), (i, jb),
                               -1) *
             SymmetricTensor(tensor_names.coulomb, (jb, bb), (a, c), 1) *
             SymmetricTensor(tensor_names.coulomb, (i, c), (jb, bb), 1)
-            + SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (j, k), -1) *  # type: ignore  # noqa E501
-            SymmetricTensor(tensor_names.coulomb, (i, j), (k, b), 1) * (  # type: ignore  # noqa E501
+            + SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (j, k), -1) *
+            SymmetricTensor(tensor_names.coulomb, (i, j), (k, b), 1) * (
                 SymmetricTensor(tensor_names.coulomb, (j, a), (k, b), 1)
                 - SymmetricTensor(tensor_names.coulomb, (j, b), (k, a), 1)
             )
-            + SymmetricTensor(tensor_names.sym_orb_denom, (a, bb), (j, kb),  # type: ignore  # noqa E501
+            + SymmetricTensor(tensor_names.sym_orb_denom, (a, bb), (j, kb),
                               -1) *
             SymmetricTensor(tensor_names.coulomb, (i, j), (kb, bb), 1) *
             SymmetricTensor(tensor_names.coulomb, (j, a), (kb, bb), 1)
@@ -324,14 +324,14 @@ class TestTransformToSpatialOrbitals:
                                                    restricted=True)
         restricted = simplify(restricted)
         ref = (
-            SymmetricTensor(tensor_names.sym_orb_denom, (b, c), (i, j), -1) *  # type: ignore  # noqa E501
+            SymmetricTensor(tensor_names.sym_orb_denom, (b, c), (i, j), -1) *
             SymmetricTensor(tensor_names.coulomb, (j, b), (a, c), 1) * (
                 SymmetricTensor(tensor_names.coulomb, (i, b), (j, c), 1)
-                - 2 * SymmetricTensor(tensor_names.coulomb, (i, c), (j, b), 1)  # type: ignore  # noqa E501
+                - 2 * SymmetricTensor(tensor_names.coulomb, (i, c), (j, b), 1)
             )
-            + SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (j, k), -1) *  # type: ignore  # noqa E501
+            + SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (j, k), -1) *
             SymmetricTensor(tensor_names.coulomb, (j, a), (k, b), 1) * (
-                2 * SymmetricTensor(tensor_names.coulomb, (j, i), (k, b), 1)  # type: ignore  # noqa E501# type: ignore  # noqa E501
+                2 * SymmetricTensor(tensor_names.coulomb, (j, i), (k, b), 1)
                 - SymmetricTensor(tensor_names.coulomb, (j, b), (k, i), 1)
             )) * SymmetricTensor(tensor_names.sym_orb_denom, (i,), (a,), -1)
         assert simplify(restricted - ref.expand()).inner is S.Zero

--- a/tests/spatial_orbitals_test.py
+++ b/tests/spatial_orbitals_test.py
@@ -21,7 +21,6 @@ class TestExpandAntiSymEri:
             AntiSymmetricTensor("d", tuple(), tuple())
         ).make_real()
         test = test.expand_antisym_eri()
-        assert tensor_names.coulomb not in test.sym_tensors
 
     def test_t2_1(self):
         t2 = Intermediates().available["t2_1"]
@@ -29,7 +28,6 @@ class TestExpandAntiSymEri:
         assert isinstance(t2, ExprContainer)
         t2.make_real()
         res = t2.expand_antisym_eri()
-        assert tensor_names.coulomb in res.sym_tensors
         i, j, a, b = get_symbols('ijab')
         ref = Add(
             SymmetricTensor(tensor_names.coulomb, (i, a), (j, b), 1),

--- a/tests/symbolic_denom_test.py
+++ b/tests/symbolic_denom_test.py
@@ -16,7 +16,7 @@ class TestSymbolicDenominators:
         original = AntiSymmetricTensor("V", (i, j), (a, b))
         original = ExprContainer(original, real=True)
         symbolic = original.copy().use_symbolic_denominators()
-        assert symbolic.inner - original.inner is S.Zero  # type: ignore
+        assert symbolic.inner - original.inner is S.Zero
 
     def test_t2_1(self):
         t2 = Intermediates().available["t2_1"]
@@ -25,7 +25,7 @@ class TestSymbolicDenominators:
         original.make_real()
         symbolic = original.copy().use_symbolic_denominators()
         i, j, a, b = get_symbols("ijab")
-        ref = (AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1) *  # type: ignore  # noqa E501
+        ref = (AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1) *
                SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (i, j), -1))
         assert symbolic.inner - ref is S.Zero
         # reintroduce the explicit denominators
@@ -33,7 +33,7 @@ class TestSymbolicDenominators:
         # need to fix the sign in the denominator for the test to pass
         explicit = EriOrbenergy(explicit).canonicalize_sign().expr
         original = EriOrbenergy(original).canonicalize_sign().expr
-        assert explicit.inner - original.inner is S.Zero  # type: ignore
+        assert explicit.inner - original.inner is S.Zero
 
     def test_t1_2(self):
         t1 = Intermediates().available["t1_2"]
@@ -50,10 +50,10 @@ class TestSymbolicDenominators:
                + Rational(1, 2) *
                Amplitude(f"{tensor_names.gs_amplitude}1", (a, b), (j, k)) *
                AntiSymmetricTensor(tensor_names.eri, (j, k), (i, b), 1))
-        ref *= SymmetricTensor(tensor_names.sym_orb_denom, (i,), (a,), -1)  # type: ignore # noqa E501
-        assert symbolic.inner - ref.expand() is S.Zero  # type: ignore
+        ref *= SymmetricTensor(tensor_names.sym_orb_denom, (i,), (a,), -1)
+        assert symbolic.inner - ref.expand() is S.Zero
         explicit = symbolic.use_explicit_denominators().expand()
-        assert explicit.inner - original.inner is S.Zero  # type: ignore
+        assert explicit.inner - original.inner is S.Zero
 
         # fully expand the itmd -> 2 denominators
         original = t1.expand_itmd(fully_expand=True)
@@ -69,8 +69,8 @@ class TestSymbolicDenominators:
                AntiSymmetricTensor(tensor_names.eri, (a, b), (j, k), 1) *
                AntiSymmetricTensor(tensor_names.eri, (j, k), (i, b), 1) *
                SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (j, k), -1))
-        ref *= SymmetricTensor(tensor_names.sym_orb_denom, (i,), (a,), -1)  # type: ignore # noqa E501
-        assert symbolic.inner - ref.expand() is S.Zero  # type: ignore
+        ref *= SymmetricTensor(tensor_names.sym_orb_denom, (i,), (a,), -1)
+        assert symbolic.inner - ref.expand() is S.Zero
         # need to fix the sign of the denominators!
         explicit = 0
         for term in symbolic.use_explicit_denominators().terms:
@@ -80,26 +80,26 @@ class TestSymbolicDenominators:
         for term in original.terms:
             ref += EriOrbenergy(term).canonicalize_sign().expr
         assert isinstance(ref, ExprContainer)
-        assert explicit.inner - ref.inner is S.Zero  # type: ignore
+        assert explicit.inner - ref.inner is S.Zero
 
     def test_squared_denom(self):
         i, j, a, b = get_symbols("ijab")
         original = AntiSymmetricTensor("V", (i, j), (a, b), 1)
         original /= (
             NonSymmetricTensor(tensor_names.orb_energy, (i,))
-            + NonSymmetricTensor(tensor_names.orb_energy, (j,))  # type: ignore
+            + NonSymmetricTensor(tensor_names.orb_energy, (j,))
             - NonSymmetricTensor(tensor_names.orb_energy, (a,))
             - NonSymmetricTensor(tensor_names.orb_energy, (b,))
         )**2
         original = ExprContainer(original, real=True)
         symbolic = original.copy().use_symbolic_denominators()
-        ref = (  # type: ignore
+        ref = (
             AntiSymmetricTensor("V", (i, j), (a, b), 1) *
             SymmetricTensor(tensor_names.sym_orb_denom, (i, j), (a, b), -1)**2
         )
         assert symbolic.inner - ref is S.Zero
         explicit = symbolic.use_explicit_denominators()
-        assert explicit.inner - original.inner is S.Zero  # type: ignore
+        assert explicit.inner - original.inner is S.Zero
 
     def test_some_denom_terms(self):
         t2 = Intermediates().available["t2_1"]
@@ -109,7 +109,7 @@ class TestSymbolicDenominators:
             + AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1)
         )
         symbolic = original.copy().use_symbolic_denominators()
-        ref = (AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1) *  # type: ignore # noqa E501
+        ref = (AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1) *
                SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (i, j), -1)
                + AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1))
         assert symbolic.inner - ref is S.Zero

--- a/tests/symbolic_denom_test.py
+++ b/tests/symbolic_denom_test.py
@@ -17,7 +17,6 @@ class TestSymbolicDenominators:
         original = ExprContainer(original, real=True)
         symbolic = original.copy().use_symbolic_denominators()
         assert symbolic.inner - original.inner is S.Zero  # type: ignore
-        assert not symbolic.antisym_tensors  # D not set
 
     def test_t2_1(self):
         t2 = Intermediates().available["t2_1"]
@@ -25,14 +24,12 @@ class TestSymbolicDenominators:
         assert isinstance(original, ExprContainer)
         original.make_real()
         symbolic = original.copy().use_symbolic_denominators()
-        assert tensor_names.sym_orb_denom in symbolic.antisym_tensors
         i, j, a, b = get_symbols("ijab")
         ref = (AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1) *  # type: ignore  # noqa E501
                SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (i, j), -1))
         assert symbolic.inner - ref is S.Zero
         # reintroduce the explicit denominators
         explicit = symbolic.use_explicit_denominators()
-        assert tensor_names.sym_orb_denom not in explicit.antisym_tensors
         # need to fix the sign in the denominator for the test to pass
         explicit = EriOrbenergy(explicit).canonicalize_sign().expr
         original = EriOrbenergy(original).canonicalize_sign().expr
@@ -46,7 +43,6 @@ class TestSymbolicDenominators:
         original.make_real()
         original.substitute_contracted()
         symbolic = original.copy().use_symbolic_denominators()
-        assert tensor_names.sym_orb_denom in symbolic.antisym_tensors
         i, j, k, a, b, c = get_symbols("ijkabc")
         ref = (Rational(1, 2) *
                Amplitude(f"{tensor_names.gs_amplitude}1", (b, c), (i, j)) *
@@ -57,7 +53,6 @@ class TestSymbolicDenominators:
         ref *= SymmetricTensor(tensor_names.sym_orb_denom, (i,), (a,), -1)  # type: ignore # noqa E501
         assert symbolic.inner - ref.expand() is S.Zero  # type: ignore
         explicit = symbolic.use_explicit_denominators().expand()
-        assert tensor_names.sym_orb_denom not in explicit.antisym_tensors
         assert explicit.inner - original.inner is S.Zero  # type: ignore
 
         # fully expand the itmd -> 2 denominators
@@ -66,7 +61,6 @@ class TestSymbolicDenominators:
         original.make_real()
         original.substitute_contracted()
         symbolic = original.copy().use_symbolic_denominators()
-        assert tensor_names.sym_orb_denom in symbolic.antisym_tensors
         ref = (Rational(1, 2) *
                AntiSymmetricTensor(tensor_names.eri, (b, c), (i, j), 1) *
                AntiSymmetricTensor(tensor_names.eri, (j, a), (b, c), 1) *
@@ -82,7 +76,6 @@ class TestSymbolicDenominators:
         for term in symbolic.use_explicit_denominators().terms:
             explicit += EriOrbenergy(term).canonicalize_sign().expr
         assert isinstance(explicit, ExprContainer)
-        assert tensor_names.sym_orb_denom not in explicit.antisym_tensors
         ref = 0
         for term in original.terms:
             ref += EriOrbenergy(term).canonicalize_sign().expr
@@ -100,7 +93,6 @@ class TestSymbolicDenominators:
         )**2
         original = ExprContainer(original, real=True)
         symbolic = original.copy().use_symbolic_denominators()
-        assert tensor_names.sym_orb_denom in symbolic.antisym_tensors
         ref = (  # type: ignore
             AntiSymmetricTensor("V", (i, j), (a, b), 1) *
             SymmetricTensor(tensor_names.sym_orb_denom, (i, j), (a, b), -1)**2
@@ -117,7 +109,6 @@ class TestSymbolicDenominators:
             + AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1)
         )
         symbolic = original.copy().use_symbolic_denominators()
-        assert tensor_names.sym_orb_denom in symbolic.antisym_tensors
         ref = (AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1) *  # type: ignore # noqa E501
                SymmetricTensor(tensor_names.sym_orb_denom, (a, b), (i, j), -1)
                + AntiSymmetricTensor(tensor_names.eri, (i, j), (a, b), 1))


### PR DESCRIPTION
Simplify the state that is stored on the `Container` classes by removing the `real`, `sym_tensors` and `antisym_tensors` assumptions. The assumptions can still be applied through the `ExprContainer` class but they are no longer stored on the class. This removes the need to update the assumptions throughout various methods.

Changes:
- Performing an operation (e.g. multiplication) of a `Container` with a raw sympy `Expr` object, the assumptions can no longer be applied automatically to the `Expr`. The bra-ket-symmetry has to be set manually before (or after) the operation.
- `expand_intermediates` now takes the bra-ket-symmetry of tensors as (optional) input argument, and applies them to the expanded expression before returning (a term 't1^{ab}_{ij}' can not know about the bra-ket-symmetry of the ERI after expansion)
- bra-ket-symmetry can now be applied to an expression through `ExprContainer.add_bra_ket_sym`
- rename `sym_tensors` and `antisym_tensors` to `braket_sym_tensors` and `braket_antisym_tensors` to avoid confusion with `SymmetricTensor` and `AntiSymmetricTensor`.